### PR TITLE
Cast Time Parameters as Double

### DIFF
--- a/qgis2fds_params.py
+++ b/qgis2fds_params.py
@@ -489,6 +489,7 @@ class StartTimeParam:
             cls.desc,
             defaultValue=defaultValue,
             optional=cls.optional,
+            type=QgsProcessingParameterNumber.Double,
         )
         algo.addParameter(param)
 
@@ -513,6 +514,7 @@ class EndTimeParam:
             cls.desc,
             defaultValue=defaultValue,
             optional=cls.optional,
+            type=QgsProcessingParameterNumber.Double,
         )
         algo.addParameter(param)
 


### PR DESCRIPTION
Initial implementation unintentionally was forcing times to signed ints.