### PR TITLE
Updated compatibility for the new QGIS version 4.0.0

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -4,8 +4,9 @@
 [general]
 name=qgis2fds
 qgisMinimumVersion=3.28
+qgisMaximumVersion=4.99
 description=Export terrains to NIST FDS for fire simulation
-version=1.0.2
+version=1.0.3
 author=Emanuele Gissi, Ruggero Poletto
 email=emanuele.gissi@gmail.com
 


### PR DESCRIPTION
When updating to QGIS to version 4, the qgis2fds plugin wasn't available anymore. Looking a little bit into it, i found the issue can be quickly solved by updating one line in the metadata.
I was then able to use the plugin locally.
While using the tool extensively now in the new QGIS version 4.0.0, i did not come across any issues.